### PR TITLE
chore: Lower Monolog version to 1.24.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3|^8.0",
-        "monolog/monolog": "^2.8"
+        "monolog/monolog": ">=1.24.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.2.2",


### PR DESCRIPTION
This is when the ProcessorInterface was introduced, and has the same format as we require in the original form.